### PR TITLE
Support for 1.11

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 2,
+    "pack_format": 3,
     "description": "The Community Pack"
   }
 }


### PR DESCRIPTION
Stop the game from yelling that the resource pack is for an older version of Minecraft.