### PR TITLE
GitHub actions functionality

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -4,11 +4,7 @@ name: CI
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: ZIP
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        # Artifact name
+        name: unity-1.14
+        # A file, directory or wildcard pattern that describes what to upload
+        path: ./

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -1,21 +1,12 @@
-# This is a basic workflow to help you get started with Actions
-
 name: ZIP
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on: [push]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
     - name: Upload a Build Artifact


### PR DESCRIPTION
Since the GitHub zip download doesn't work properly I thought I'd set up a GitHub action that built a zip of the pack.

YOu can check out the result here: https://github.com/UndarkAido/Unity/actions

(I cancelled the most recent one because I thought it was uploading every file individually, all I changed is the CI name)